### PR TITLE
docs: improve README with complete examples, dependencies, and troubl…

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,36 @@
 
 The sugar4 library contains a set of widgets to build HIG compliant applications and interfaces to interact with system services like presence and the datastore.
 
+## Dependencies
+
+Before building, ensure you have the required dependencies installed:
+
+### Ubuntu/Debian
+```bash
+sudo apt-get install meson ninja-build libgtk-4-dev libglib2.0-dev
+```
+
+### Fedora/RHEL
+```bash
+sudo dnf install meson ninja-build gtk4-devel glib2-devel
+```
+
+### Arch Linux
+```bash
+sudo pacman -S meson ninja gtk4 glib2
+```
+
+### macOS
+```bash
+brew install meson ninja gtk4 glib
+```
+
+### Required Versions
+- GTK4 >= 4.0
+- GLib >= 2.70
+- Meson >= 0.56
+- Ninja
+
 ## Building
 
 This project uses Meson build system:
@@ -34,19 +64,62 @@ Tests include:
 meson install -C builddir
 ```
 
-## Examples > [!WARNING]
+## Examples
+
+After building, you can run the example programs:
 
 ```bash
-meson compile -C builddir 
-# then follow by the example you want to run
+# Grid layout example
 ./builddir/examples/sugar_grid_example
+
+# Event controller example
 ./builddir/examples/sugar_event_controller_example
+
+# File attributes example
 ./builddir/examples/sugar_file_attributes_example
+
+# Long press controller example
+./builddir/examples/sugar_long_press_controller_example
 ```
 
-## Dependencies
+> [!NOTE]
+> Examples require a display server (X11 or Wayland). If running in a headless environment, use `xvfb-run`:
+> ```bash
+> xvfb-run ./builddir/examples/sugar_grid_example
+> ```
 
-- GTK4 >= 4.0
-- GLib >= 2.70
-- GObject
-- GIO
+## Troubleshooting
+
+### Meson not found
+If you get `meson: command not found`, install Meson using your package manager or pip:
+```bash
+pip install --user meson ninja
+```
+
+### GTK4 version incompatibility
+Ensure you have GTK4 >= 4.0 installed:
+```bash
+pkg-config --modversion gtk4
+```
+
+### Display server issues
+If examples fail with display errors:
+- Ensure `DISPLAY` environment variable is set
+- Use `xvfb-run` for headless environments
+- Check that your system supports GTK4 (Wayland or X11)
+
+### Build directory conflicts
+If you encounter build errors, try cleaning and rebuilding:
+```bash
+rm -rf builddir
+meson setup builddir
+meson compile -C builddir
+```
+
+### Missing dependencies
+If compilation fails with missing headers:
+- Verify all dependencies are installed (see Dependencies section)
+- Check that pkg-config can find the libraries:
+  ```bash
+  pkg-config --cflags --libs gtk4 glib-2.0
+  ```

--- a/README.md
+++ b/README.md
@@ -4,29 +4,6 @@ The sugar4 library contains a set of widgets to build HIG compliant applications
 
 ## Dependencies
 
-Before building, ensure you have the required dependencies installed:
-
-### Ubuntu/Debian
-```bash
-sudo apt-get install meson ninja-build libgtk-4-dev libglib2.0-dev
-```
-
-### Fedora/RHEL
-```bash
-sudo dnf install meson ninja-build gtk4-devel glib2-devel
-```
-
-### Arch Linux
-```bash
-sudo pacman -S meson ninja gtk4 glib2
-```
-
-### macOS
-```bash
-brew install meson ninja gtk4 glib
-```
-
-### Required Versions
 - GTK4 >= 4.0
 - GLib >= 2.70
 - Meson >= 0.56
@@ -69,57 +46,20 @@ meson install -C builddir
 After building, you can run the example programs:
 
 ```bash
-# Grid layout example
 ./builddir/examples/sugar_grid_example
-
-# Event controller example
 ./builddir/examples/sugar_event_controller_example
-
-# File attributes example
 ./builddir/examples/sugar_file_attributes_example
-
-# Long press controller example
 ./builddir/examples/sugar_long_press_controller_example
 ```
-
-> [!NOTE]
-> Examples require a display server (X11 or Wayland). If running in a headless environment, use `xvfb-run`:
-> ```bash
-> xvfb-run ./builddir/examples/sugar_grid_example
-> ```
 
 ## Troubleshooting
 
 ### Meson not found
-If you get `meson: command not found`, install Meson using your package manager or pip:
 ```bash
 pip install --user meson ninja
 ```
 
-### GTK4 version incompatibility
-Ensure you have GTK4 >= 4.0 installed:
-```bash
-pkg-config --modversion gtk4
-```
-
-### Display server issues
-If examples fail with display errors:
-- Ensure `DISPLAY` environment variable is set
-- Use `xvfb-run` for headless environments
-- Check that your system supports GTK4 (Wayland or X11)
-
 ### Build directory conflicts
-If you encounter build errors, try cleaning and rebuilding:
 ```bash
-rm -rf builddir
-meson setup builddir
-meson compile -C builddir
+meson setup builddir --wipe
 ```
-
-### Missing dependencies
-If compilation fails with missing headers:
-- Verify all dependencies are installed (see Dependencies section)
-- Check that pkg-config can find the libraries:
-  ```bash
-  pkg-config --cflags --libs gtk4 glib-2.0
-  ```


### PR DESCRIPTION
issue:#4
I had added:
Dependencies section - Install commands for Ubuntu, Fedora, Arch, and macOS
Fixed Examples - Complete command paths for all 4 examples (were truncated)
Troubleshooting section - Solutions for common build/runtime errors
into the readme  